### PR TITLE
Popen doesn't execute wine command array when shell=True

### DIFF
--- a/mt5linux/__main__.py
+++ b/mt5linux/__main__.py
@@ -168,7 +168,7 @@ def main():
             host,
             '-p',
             str(port),
-        ],shell=True,
+        ],
     ).wait()
 
 

--- a/mt5linux/__main__.py
+++ b/mt5linux/__main__.py
@@ -168,7 +168,7 @@ def main():
             host,
             '-p',
             str(port),
-        ],
+        ]
     ).wait()
 
 

--- a/mt5linux/__main__.py
+++ b/mt5linux/__main__.py
@@ -158,7 +158,7 @@ def main():
     port=args.port
     host=args.host
     #
-    Popen(['mkdir','-p',server_dir],shell=True).wait()
+    Popen(['mkdir','-p',server_dir]).wait()
     __generate_server_classic(os.path.join(server_dir,server_code))
     Popen([
             wine_cmd,


### PR DESCRIPTION
I get a error when  run server

```sh
env WINEPREFIX=$HOME/.mt5 python -m mt5linux "$HOME/.mt5/dosdevices/c:/users/$USER/AppData/Local/Programs/Python/Python310-32/python.exe"
```
and get result
```
mkdir: missing operand
Try 'mkdir --help' for more information.
Usage: wine PROGRAM [ARGUMENTS...]   Run the specified program
       wine --help                   Display this help and exit
       wine --version                Output version information and exit
```

I found that remove `shell=True` parameter in Popen can fix it

- OS: Ubuntu 24.04
- Wine: wine-9.8 (Staging)
- Python: Python 3.10-32 bit