### PR TITLE
Fix RPyC 6 compatibility

### DIFF
--- a/mt5linux/__main__.py
+++ b/mt5linux/__main__.py
@@ -1,1 +1,9 @@
-"""\n#!/usr/bin/env python\n\n# Code from: https://github.com/tomerfiliba-org/rpyc\n    \nclassic rpyc server (threaded, forking or std) running a SlaveService\nusage:\n    rpyc_classic.py                         # default settings\n    rpyc_classic.py -m forking -p 12345     # custom settings\n\n    # ssl-authenticated server (keyfile and certfile are required)\n    rpyc_classic.py --ssl-keyfile keyfile.pem --ssl-certfile certfile.pem --ssl-cafile cafile.pem\n"""\n\nimport sys\nimport os\nimport rpyc\nfrom plumbum import cli\nfrom rpyc.utils.server import ThreadedServer, ForkingServer, OneShotServer\nfrom rpyc.utils.classic import DEFAULT_SERVER_PORT, DEFAULT_SERVER_SSL_PORT\nfrom rpyc.utils.registry import REGISTRY_PORT\nfrom rpyc.utils.registry import UDPRegistryClient, TCPRegistryClient\nfrom rpyc.utils.authenticators import SSLAuthenticator\nfrom rpyc.lib import setup_logger\nfrom rpyc.core import SlaveService\nfrom rpyc.core.async_ import TimeoutError as RpycTimeoutError\n\nclass ClassicServer(cli.Application):\n    mode = cli.SwitchAttr(\n        ["-m", "--mode"],\n        cli.Set("threaded", "forking", "stdio", "oneshot"),\n        default="threaded",\n        help="The serving mode (threaded, forking, or 'stdio' for \
+"""Command-line entrypoint for the mt5linux RPyC classic server."""
+
+from __future__ import annotations
+
+from rpyc.cli.rpyc_classic import ClassicServer
+
+
+if __name__ == "__main__":
+    ClassicServer.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "numpy",
     "plumbum==1.7.0",
     "pyparsing>=3.1.0,<4",
-    "rpyc==5.2.3",
+    "rpyc>=6.0.0,<7",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 plumbum==1.7.0
 pyparsing==2.4.7
-rpyc==5.2.3
+rpyc>=6.0.0,<7


### PR DESCRIPTION
## Summary
- update the RPyC dependency constraint to allow the patched 6.x series
- replace the malformed copied classic-server entrypoint with RPyC's maintained `rpyc_classic` CLI entrypoint

## Validation
- `python3 -m py_compile mt5linux/__main__.py mt5linux/metatrader5.py`
- fresh venv: `python -m pip install -e .`
- fresh venv: `python -m pip check`
- fresh venv: import smoke confirmed `rpyc 6.0.2` and `mt5linux.MetaTrader5`
- fresh venv: `python -m mt5linux --help`
- fresh venv: `python -m unittest tests.test_order_check`
- fresh venv: `python -m build`

## Notes
- `python -m unittest discover tests` still imports `tests/test_01.py`, which attempts a live `MetaTrader5(port=1235)` connection at import time; I did not treat that live-environment failure as part of this dependency-only validation.