### PR TITLE
fix: change typo NVC to VNC

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       MT5_HOST: ${MT5_HOST:-0.0.0.0}
       VNC_PASSWORD: ${VNC_PASSWORD:-password}
     ports:
-      - ${NVC_PORT:-6081}:6081
+      - ${VNC_PORT:-6081}:6081
       - ${MT5_PORT:-18812}:18812
     restart: "no"
     stdin_open: true


### PR DESCRIPTION
Fix typo `NVC` to `VNC`