### PR TITLE
Verify AutoTrading toolbar is enabled at runtime

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -64,6 +64,7 @@ Environment variables can be configured via `.env` file or directly in `docker-c
 | `MT5_LOGIN`      | (none)     | MT5 account number for autologin                 |
 | `MT5_PASSWORD`   | (none)     | MT5 password for autologin                       |
 | `MT5_SERVER`     | (none)     | MT5 server name for autologin                    |
+| `MT5_ENABLE_ALGO`| `0`        | Set to `1` to allow algorithmic trading (`order_send`); off by default |
 | `NOVNC_HOST`     | `localhost`| Host for noVNC UI URL                            |
 
 ## Autologin

--- a/docker/src/algo_trading.sh
+++ b/docker/src/algo_trading.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# Runtime enablement + verification of MT5 algorithmic trading (the "AutoTrading"
+# toolbar button). Companion to the common.ini [Experts] AllowLiveTrading gate in
+# config.sh: that sets the *global* "Allow Algo Trading" option, but the toolbar
+# button is a session toggle that MT5 does NOT reliably restore from config — a
+# volume carrying a previously-disabled toolbar state can leave order_send()
+# failing with retcode 10027 even when AllowLiveTrading=1.
+#
+# This clicks the toolbar button and CONFIRMS via the terminal journal, counting
+# only events logged after this boot so a stale "enabled" line from an earlier
+# session cannot produce a false positive. Gated by MT5_ENABLE_ALGO=1.
+set -e
+
+# MT5 portable-mode journal dir (terminal64.exe /portable puts logs beside itself).
+ALGO_LOG_DIR="$MT5/logs"
+
+# Toolbar AutoTrading button position. The button has no config representation and
+# no reliable hotkey, so a synthetic click is required. Coordinates depend on the
+# terminal window geometry; override via MT5_ALGO_BUTTON_XY="x y" for other layouts.
+ALGO_BUTTON_XY="${MT5_ALGO_BUTTON_XY:-290 55}"
+
+# Latest journal file, or empty.
+_algo_journal() { ls -t "$ALGO_LOG_DIR"/*.log 2>/dev/null | head -n1; }
+
+# Count "automated trading is (enabled|disabled)" lines in the current journal.
+# MT5 journals are UTF-16 (a NUL byte between each ASCII char); without stripping
+# the NULs the grep never matches and the count is always 0. This is the crux of
+# reliable verification.
+_algo_events() {
+  f=$(_algo_journal); [ -z "$f" ] && { echo 0; return; }
+  tr -d '\000' < "$f" | grep -c "automated trading is" 2>/dev/null || echo 0
+}
+
+# The most recent enable/disable line (NULs stripped), for the enabled/disabled check.
+_algo_last() {
+  f=$(_algo_journal); [ -z "$f" ] && return
+  tr -d '\000' < "$f" | grep -i "automated trading is" | tail -n1
+}
+
+enable_algo_automation() {
+  [ "${MT5_ENABLE_ALGO:-0}" = "1" ] || return 0
+
+  # Wait for the terminal window.
+  win=""
+  i=0
+  while [ $i -lt 60 ]; do
+    win=$(xdotool search --classname terminal64.exe 2>/dev/null | head -n1)
+    [ -n "$win" ] && break
+    i=$((i + 1)); sleep 5
+  done
+  [ -z "$win" ] && { log_error "enable-algo: no MT5 window found"; return 0; }
+
+  # Let login + terminal fully settle; clicks during early boot don't register.
+  sleep 40
+
+  base=$(_algo_events)   # journal lines predating our toggling
+  i=0
+  while [ $i -lt 20 ]; do
+    # Click FIRST, then verify, so an enabling click on the final iteration still
+    # counts. Re-resolve the window id each pass in case it changed.
+    win=$(xdotool search --classname terminal64.exe 2>/dev/null | head -n1)
+    xdotool windowactivate --sync "$win" 2>/dev/null || true
+    sleep 0.5
+    # shellcheck disable=SC2086
+    xdotool mousemove $ALGO_BUTTON_XY click 1
+    sleep 3
+    if [ "$(_algo_events)" -gt "$base" ]; then
+      case "$(_algo_last)" in
+        *[Ee]nabled*) log_info "enable-algo: algorithmic trading enabled"; return 0 ;;
+      esac
+    fi
+    i=$((i + 1))
+  done
+  log_error "enable-algo: could not confirm enablement after retries"
+  return 0
+}

--- a/docker/src/config.sh
+++ b/docker/src/config.sh
@@ -22,6 +22,7 @@ MaxBars=1000000
 
 [Experts]
 Enabled=0
+AllowLiveTrading=0
 
 [News]
 Enabled=0
@@ -116,6 +117,18 @@ EOFTERMINAL
   fi
   if [ -n "$MT5_PASSWORD" ]; then
     sed -i "s/^Password=$/Password=$MT5_PASSWORD/" /tmp/common_ini.txt
+  fi
+
+  # Opt-in algorithmic trading. MT5 rejects order_send() with retcode 10027
+  # ("AutoTrading disabled by client") unless "Allow Algo Trading" is on, which is
+  # gated by [Experts] AllowLiveTrading in common.ini. Default stays 0 so data-only
+  # users are unaffected; set MT5_ENABLE_ALGO=1 to trade. The sed is scoped to the
+  # [Experts] section so it can't flip the other [News]/[Signal]/[MarketWatch]
+  # Enabled=0 lines.
+  if [ "${MT5_ENABLE_ALGO:-0}" = "1" ]; then
+    sed -i -e '/^\[Experts\]$/,/^\[/ s/^Enabled=0$/Enabled=1/' \
+           -e '/^\[Experts\]$/,/^\[/ s/^AllowLiveTrading=0$/AllowLiveTrading=1/' \
+           /tmp/common_ini.txt
   fi
 
   iconv -f UTF-8 -t UTF-16LE /tmp/common_ini.txt >"$common_ini"

--- a/docker/src/main.sh
+++ b/docker/src/main.sh
@@ -7,6 +7,7 @@ set -e
 . /app/src/xvfb.sh
 . /app/src/vnc.sh
 . /app/src/automation.sh
+. /app/src/algo_trading.sh
 . /app/src/config.sh
 . /app/src/mt5.sh
 
@@ -34,6 +35,11 @@ apply_mt5_config
 start_mt5
 wait_for_mt5_and_type_server &
 MT5_SETUP_PID=$!
+
+# When MT5_ENABLE_ALGO=1, enable the AutoTrading toolbar and confirm via the
+# journal (no-op otherwise). Complements the common.ini AllowLiveTrading gate.
+enable_algo_automation &
+ALGO_PID=$!
 
 start_rpyc_server
 start_watchdog

--- a/docker/test/test_algo_config.sh
+++ b/docker/test/test_algo_config.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# Test harness for the mt5linux AutoTrading (retcode 10027) config gap + proposed fix.
+#
+# Reproduces docker/src/config.sh's common.ini generation in isolation, so the bug
+# and the fix are verifiable without running MT5 under Wine.
+#
+#   BUG   : [Experts] Enabled=0 and no AllowLiveTrading -> order_send fails 10027.
+#   FIX   : opt-in MT5_ENABLE_ALGO=1 sets BOTH keys, section-scoped so the other
+#           three Enabled=0 lines (News/Signal/MarketWatch) are untouched.
+#
+# Run:  sh test_algo_config.sh    (exit 0 = all assertions pass)
+set -e
+fail=0
+check() {  # check "name" "expected" "actual"
+  if [ "$2" = "$3" ]; then printf '  PASS  %s\n' "$1"
+  else printf '  FAIL  %s\n       expected [%s] got [%s]\n' "$1" "$2" "$3"; fail=1; fi
+}
+
+# ── verbatim slice of the [Experts] region as config.sh writes it (post-fix heredoc) ──
+# The fix adds one line: AllowLiveTrading=0 under [Experts]. Everything else is upstream.
+make_ini() {
+  cat <<'EOF'
+[Common]
+Login=
+Server=
+Password=
+[Experts]
+Enabled=0
+AllowLiveTrading=0
+[News]
+Enabled=0
+AutoUpdate=0
+[Signal]
+Enabled=0
+AutoUpdate=0
+[MarketWatch]
+Enabled=0
+EOF
+}
+
+# ── the proposed fix: section-scoped sed, opt-in via MT5_ENABLE_ALGO ──────────
+apply_algo_fix() {  # reads stdin, writes stdout; env MT5_ENABLE_ALGO
+  if [ "${MT5_ENABLE_ALGO:-0}" = "1" ]; then
+    sed -e '/^\[Experts\]$/,/^\[/ s/^Enabled=0$/Enabled=1/' \
+        -e '/^\[Experts\]$/,/^\[/ s/^AllowLiveTrading=0$/AllowLiveTrading=1/'
+  else
+    cat
+  fi
+}
+
+experts_val() {  # experts_val <ini> <key> -> value in the [Experts] section only
+  awk -v k="$2" '
+    /^\[/{sec=$0} sec=="[Experts]" && $0 ~ "^"k"="{split($0,a,"="); print a[2]; exit}
+  ' "$1"
+}
+count_enabled0() { grep -c '^Enabled=0$' "$1"; }
+
+TMP=$(mktemp -d)
+
+# ── 1. DEFAULT (no env) = upstream behaviour, unchanged (the bug persists) ─────
+make_ini | apply_algo_fix > "$TMP/default.ini"
+check "default: [Experts] Enabled stays 0"           "0" "$(experts_val "$TMP/default.ini" Enabled)"
+check "default: [Experts] AllowLiveTrading stays 0"  "0" "$(experts_val "$TMP/default.ini" AllowLiveTrading)"
+check "default: all 4 Enabled=0 lines intact"        "4" "$(count_enabled0 "$TMP/default.ini")"
+
+# ── 2. OPT-IN (MT5_ENABLE_ALGO=1) = algo trading enabled ──────────────────────
+MT5_ENABLE_ALGO=1 make_ini | MT5_ENABLE_ALGO=1 apply_algo_fix > "$TMP/algo.ini"
+check "opt-in: [Experts] Enabled -> 1"               "1" "$(experts_val "$TMP/algo.ini" Enabled)"
+check "opt-in: [Experts] AllowLiveTrading -> 1"      "1" "$(experts_val "$TMP/algo.ini" AllowLiveTrading)"
+
+# ── 3. SCOPING GUARANTEE: News/Signal/MarketWatch NOT touched ─────────────────
+# 4 Enabled=0 originally; opt-in flips exactly ONE ([Experts]) -> 3 remain.
+check "opt-in: only [Experts] flipped, other 3 intact" "3" "$(count_enabled0 "$TMP/algo.ini")"
+
+rm -rf "$TMP"
+echo
+if [ "$fail" = 0 ]; then echo "all assertions passed — bug reproduced, fix correct, scoping safe"; else echo "FAILURES"; exit 1; fi

--- a/docker/test/test_algo_journal.sh
+++ b/docker/test/test_algo_journal.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Test the journal-verification logic in algo_trading.sh WITHOUT MT5/Wine/X.
+#
+# Only the journal reading is exercised here (the xdotool clicking needs a live
+# terminal window and is validated in-container). The point under test is the
+# UTF-16 handling: MT5 journals are UTF-16LE, and a naive grep silently returns 0.
+set -e
+fail=0
+check() { if [ "$2" = "$3" ]; then printf '  PASS  %s\n' "$1"
+  else printf '  FAIL  %s (expected [%s] got [%s])\n' "$1" "$2" "$3"; fail=1; fi; }
+
+export MT5=$(mktemp -d)
+export ALGO_LOG_DIR="$MT5/logs"; mkdir -p "$ALGO_LOG_DIR"
+
+# Source the helpers only (guard against running enable_algo_automation).
+. /root/app/oss/mt5linux/docker/src/algo_trading.sh 2>/dev/null || true
+
+# Build a realistic UTF-16LE journal (this is how MT5 actually writes it).
+utf16() { iconv -f UTF-8 -t UTF-16LE; }
+{
+  printf '0\t14:00:00.000\tTerminal\tMetaTrader 5 build 4200 started\n'
+  printf '0\t14:00:01.000\tExperts\tautomated trading is disabled\n'
+} | utf16 > "$ALGO_LOG_DIR/20260808.log"
+
+# 1. NUL-stripped count sees both matching lines (naive grep would see 0).
+check "UTF-16 journal: events counted after NUL strip" "1" "$(_algo_events)"
+
+# 1b. prove the naive path fails: grep straight on the UTF-16 file finds nothing.
+naive=$(grep -c "automated trading is" "$ALGO_LOG_DIR/20260808.log" 2>/dev/null || true)
+check "control: naive grep on UTF-16 returns 0 (the trap)" "0" "$naive"
+
+# 2. last line reflects current state = disabled.
+case "$(_algo_last)" in *disabled*) got=disabled ;; *) got=other ;; esac
+check "last event parsed as disabled" "disabled" "$got"
+
+# 3. append an ENABLED line -> count rises, last flips to enabled (post-click state).
+printf '0\t14:05:00.000\tExperts\tautomated trading is enabled\n' | utf16 >> "$ALGO_LOG_DIR/20260808.log"
+check "after enable: event count is 2" "2" "$(_algo_events)"
+case "$(_algo_last)" in *[Ee]nabled*) case "$(_algo_last)" in *disabled*) got=disabled;; *) got=enabled;; esac ;; *) got=other ;; esac
+check "last event now enabled" "enabled" "$got"
+
+# 4. no journal at all -> 0, no crash (early-boot case).
+rm -f "$ALGO_LOG_DIR"/*.log
+check "empty log dir: count is 0" "0" "$(_algo_events)"
+
+rm -rf "$MT5"
+echo
+if [ "$fail" = 0 ]; then echo "all assertions passed — UTF-16 journal verification correct"; else exit 1; fi


### PR DESCRIPTION
## Summary
- Follow-up to #52. `AllowLiveTrading=1` sets the global option, but the toolbar AutoTrading button is a session toggle MT5 doesn't reliably restore — a `/config` volume with a persisted-off state can still fail `order_send()` with 10027.
- When `MT5_ENABLE_ALGO=1`, click the toolbar button and confirm via the terminal journal.

## Changes Made
- `docker/src/algo_trading.sh`: `enable_algo_automation()` — waits for the terminal window, clicks the AutoTrading button, and verifies enablement from the journal, counting only post-boot events so a stale line can't false-positive.
- `docker/src/main.sh`: source it and dispatch `enable_algo_automation &` like the other `*_automation` helpers.
- `docker/test/test_algo_journal.sh`: tests the journal-verification logic.

## Testing
`sh docker/test/test_algo_journal.sh` — passes, including a control proving a naive `grep` on the raw journal returns 0.

Key detail: **MT5 journals are UTF-16LE**; the NUL bytes must be stripped (`tr -d '\000'`) before matching or the count is always 0.

**Limitation:** the journal logic is unit-tested offline, but the `xdotool` click path needs validation in a live container — I can't drive a real terminal window in isolation. The click coordinate defaults to `290 55` and is overridable via `MT5_ALGO_BUTTON_XY`; happy to align it to the repo's xvfb layout.

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated (env var covered by PR 1)
- [x] Tests added (journal logic; click path pending in-container)
- [x] No breaking changes (no-op unless `MT5_ENABLE_ALGO=1`)

## Related Issues
Refs #51. Builds on #52.

## Additional Notes
Same production provenance as PR 1.
